### PR TITLE
Apply minor tweaks to translation CI.

### DIFF
--- a/.github/workflows/prevent-translation-changes.yaml
+++ b/.github/workflows/prevent-translation-changes.yaml
@@ -5,12 +5,12 @@ on:
     types: [opened, reopened, synchronize]
 
 jobs:
-  check-tranlsation-diff:
+  check-translation-diff:
     if: github.actor != 'github-actions[bot]' && !contains(github.event.pull_request.title, 'Update Translations')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
-      - name: Checkout
+      - name: Checkout Repository
         uses: actions/checkout@v4
 
       - name: Check For Translation Changes


### PR DESCRIPTION
1. Sets "latest" to 22.04 as this is the same choice used in main workflow script,
2. Extends the checkout job title,
3. Fixes a typo for the check translation diff.